### PR TITLE
MNT: Replace master with main

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ About
     :alt: CI Status
     :target: https://github.com/astropy/astropy-changelog/actions
 
-.. image:: https://codecov.io/gh/astropy/astropy-changelog/branch/master/graph/badge.svg
+.. image:: https://codecov.io/gh/astropy/astropy-changelog/branch/main/graph/badge.svg
     :alt: Coverage
     :target: https://codecov.io/gh/astropy/astropy-changelog
 


### PR DESCRIPTION
This PR attempts to replace all mention of `master` to `main` in this repository. This should be reviewed and merged right after the maintainer has renamed the default branch.

This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.

This is part of #4